### PR TITLE
docs: refresh community plugin installation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,9 +211,9 @@ Examples:
 - Tag `1.3.0-beta.1` requires `## [1.3.0-beta.1]`
 - Tag `1.3.0` requires `## [1.3.0]`
 
-### Prerelease flow (BRAT testing)
+### Prerelease flow
 
-Use prerelease tags when you want testers to validate a PR-branch build before final release:
+Use prerelease tags when you want testers to validate a build before final release. If the work is still in a PR branch, BRAT can be used as an optional beta-testing path:
 
 ```bash
 pnpm version 1.3.0-beta.1 --no-git-tag-version

--- a/README.md
+++ b/README.md
@@ -1,32 +1,37 @@
 # Smart Export
 
-[![CI/CD](https://github.com/LittleHaku/obsidian-smart-export/actions/workflows/ci.yml/badge.svg)](https://github.com/LittleHaku/obsidian-smart-export/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/LittleHaku/obsidian-smart-export/branch/main/graph/badge.svg)](https://codecov.io/gh/LittleHaku/obsidian-smart-export/branch/main)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Version](https://img.shields.io/github/v/release/LittleHaku/obsidian-smart-export)](https://github.com/LittleHaku/obsidian-smart-export/releases)
-[![Downloads](https://img.shields.io/github/downloads/LittleHaku/obsidian-smart-export/total)](https://github.com/LittleHaku/obsidian-smart-export/releases)
+[![Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=Downloads&query=%24%5B%22smart-export%22%5D.downloads&suffix=%20installs&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json)](https://obsidian.md/plugins?id=smart-export)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support%20me-orange?logo=buy-me-a-coffee&logoColor=white&style=flat)](https://buymeacoffee.com/littlehaku)
 
-Smart Export follows links from a root note, builds a note tree, and exports it in formats that work well for both humans and LLMs.
+Smart Export turns one Obsidian note into a clean exportable context bundle by following wikilinks to a configurable depth. It is built for people who want readable note packets, print-friendly exports, or structured context for LLM workflows without manually stitching notes together.
 
-## 1 Installation
+## Why Smart Export
 
-### 1.1 BRAT (current installation method)
+- Follow outgoing links, backlinks, or both from a root note.
+- Export as XML, print-friendly Markdown, or Markdown templates such as `LLM-ready`.
+- Exclude folders, tags, and frontmatter-based note groups from traversal.
+- Copy exports to the clipboard or create a new note directly in your vault.
+- Rewrite links between exported notes so navigation still works inside the generated Markdown note.
 
-Use [BRAT (Beta Reviewers Auto-update Tool)](https://github.com/TfTHacker/obsidian42-brat):
+## Installation
+
+### Community Plugins (recommended)
+
+1. Open **Settings → Community plugins**.
+2. Turn off **Restricted mode** if needed.
+3. Click **Browse**, search for **Smart Export**, then install and enable it.
+
+### BRAT (optional beta testing only)
+
+Use [BRAT (Beta Reviewers Auto-update Tool)](https://github.com/TfTHacker/obsidian42-brat) only if you want to test prerelease builds before they reach the Community Plugins catalog.
 
 1. In Obsidian, open **Settings → Community plugins → Browse** and install **BRAT**.
 2. Open BRAT settings and click **Add a beta plugin**.
 3. Paste: `https://github.com/LittleHaku/obsidian-smart-export`
-4. Select the latest release.
+4. Select the latest prerelease you want to test.
 
-### 1.2 Community plugins (when available)
-
-1. Open **Settings → Community plugins**.
-2. Turn off **Restricted mode**.
-3. Click **Browse**, search for **Smart Export**, then install and enable it.
-
-## 2 Quick Start
+## Quick Start
 
 1. Open command palette (`Cmd/Ctrl+P`) and run `Smart Export: Open export` (or click the ribbon icon).
 2. Select a root note.
@@ -36,28 +41,32 @@ Use [BRAT (Beta Reviewers Auto-update Tool)](https://github.com/TfTHacker/obsidi
 
 `Export to new note` prompts for a vault-relative folder and note name, then creates the Markdown note using your default folder/open preferences from settings.
 
-## 3 Features
+## Export Formats
+
+- **XML** for structured machine-readable exports.
+- **LLM-ready Markdown** for prompt and context workflows.
+- **Print-friendly Markdown** for readable note bundles, PDF export, and linked tables of contents.
+- **Custom Markdown templates** loaded from your vault.
+
+## Core Features
 
 - Smart note discovery using breadth-first traversal.
 - Link direction modes: outgoing, incoming, or both.
 - Dual depth controls:
-  - content depth (full content)
-  - title depth (title-only context)
-- Folder exclusion (`Ignored folders`) for traversal with comma-separated wildcard/path patterns.
-- Tag/property exclusion rules for traversal (`Hide notes with tags`, `Hide notes with property rules`).
-- Output formats: XML, Markdown templates, Print-friendly Markdown.
-- Multiple Markdown templates (built-in + custom folder templates) with placeholder support.
-- Export delivery options: copy to clipboard or create a new note in the vault after choosing folder and note name.
-- Markdown-based exports rewrite links to exported notes into Obsidian heading links so they stay navigable inside the generated note.
-- Print-friendly Markdown can add a linked table of contents, numbered headings, section dividers, or page breaks for easier PDF scanning.
-- After plugin updates, Smart Export shows a one-time what's new modal with release highlights and quick actions.
+  - content depth for full note content
+  - title depth for title-only context
+- Folder exclusion with comma-separated wildcard or path patterns.
+- Tag and property exclusion rules for traversal.
+- Linked table of contents, numbered headings, section dividers, and page breaks for print-friendly Markdown.
+- Built-in and custom Markdown templates with placeholder support.
 - Token estimate display before export.
+- One-time in-app "What's new" modal after plugin updates.
 
-## 4 Settings
+## Settings
 
 Settings location: **Obsidian → Settings → Smart Export**
 
-### 4.1 Export defaults
+### Export defaults
 
 - **Default content depth**: `1-20`
 - **Default title depth**: `1-20`
@@ -66,24 +75,24 @@ Settings location: **Obsidian → Settings → Smart Export**
 - **Default link direction**
 - **Default export note folder**: vault-relative folder for new export notes (leave empty to use the source note folder)
 
-### 4.2 Traversal exclusions
+### Traversal exclusions
 
 - **Ignored folders**: comma-separated folders/patterns (for example `templates, assets*, /archive`) excluded from traversal/export. Leading `/` anchors to vault root.
 - **Hide notes with tags**: comma-separated tag patterns (for example `archive*, #draft, projects/*/old`) excluded from traversal/export.
 - **Hide notes with property rules**: comma-separated rules using `key` or `key=value` (for example `status=done, published=true, archived`) excluded from traversal/export.
 
-### 4.3 Markdown templates
+### Markdown templates
 
 - **Markdown template folder**: vault-relative folder for custom Markdown templates, with folder autocomplete
 
-### 4.4 Print-friendly Markdown
+### Print-friendly Markdown
 
 - **Include table of contents**: adds a linked table of contents to print-friendly exports
 - **Number headings**: prefixes exported note headings with section numbers such as `1.` and `1.1`
 - **Insert section dividers**: adds divider lines between note sections in print-friendly exports
 - **Insert page breaks**: starts each note section after the first on a new page and replaces section dividers
 
-### 4.5 Export modal behavior
+### Export modal behavior
 
 - **Auto-select current note**
 - **Close modal after export**
@@ -92,7 +101,7 @@ Settings location: **Obsidian → Settings → Smart Export**
 
 Exclusion details (folders/tags/properties): [Exclusion rules](docs/exclude-folders.md)
 
-### 4.6 Using Markdown templates
+## Using Markdown Templates
 
 For Markdown template exports, Smart Export can load a custom template from your vault:
 
@@ -126,13 +135,13 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 `{{metadata_yaml}}` includes the full YAML block with `---` delimiters and keys like
 `export_timestamp`, `starting_note`, `total_notes_exported`, and `missing_notes_count`.
 
-## 5 Keyboard Shortcut
+## Keyboard Shortcuts
 
 - Primary command: `Smart Export: Open export`
 - Quick command: `Smart Export: Quick export current note` (uses default settings and follows your configured default export target)
 - Assign your own shortcut in **Settings → Hotkeys**.
 
-## 6 Documentation
+## Documentation
 
 - [Documentation index](docs/README.md)
 - [API reference](docs/api-reference.md)
@@ -144,9 +153,9 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Roadmap and feature backlog (GitHub Issues)](https://github.com/LittleHaku/obsidian-smart-export/issues)
 
-## 7 Example Output
+## Example Output
 
-### 7.1 XML (excerpt)
+### XML (excerpt)
 
 ```xml
 <obsidian_export>
@@ -157,7 +166,7 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 </obsidian_export>
 ```
 
-### 7.2 LLM Markdown (excerpt)
+### LLM Markdown (excerpt)
 
 ```markdown
 # Smart Export Vault
@@ -166,15 +175,15 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 - Total Notes: 5
 ```
 
-## 8 Troubleshooting
+## Troubleshooting
 
-### 8.1 Empty export or missing notes
+### Empty export or missing notes
 
 - Ensure the root note exists.
 - Ensure links resolve to real notes.
 - Check that excluded folders are not filtering expected notes.
 
-### 8.2 Export too large
+### Export too large
 
 - Use **Export to new note** to avoid clipboard limits for large exports.
 - Set **Default export target** to `New note` if your quick-export hotkey should create files instead of using the clipboard.
@@ -182,7 +191,7 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 - Switch to Print-friendly Markdown.
 - Start from a more specific root note.
 
-## 9 Contributing
+## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -209,7 +218,7 @@ Benchmark:
 pnpm benchmark
 ```
 
-## 10 Support
+## Support
 
 - Star the repo.
 - Report bugs and request features in [GitHub Issues](https://github.com/LittleHaku/obsidian-smart-export/issues).
@@ -217,6 +226,6 @@ pnpm benchmark
 
 [![Star History Chart](https://api.star-history.com/image?repos=LittleHaku/obsidian-smart-export&type=date&legend=top-left)](https://www.star-history.com/?repos=LittleHaku%2Fobsidian-smart-export&type=date&legend=top-left)
 
-## 11 License
+## License
 
 MIT License. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Smart Export turns one Obsidian note into a clean exportable context bundle by f
 
 - Follow outgoing links, backlinks, or both from a root note.
 - Export as XML, print-friendly Markdown, or Markdown templates such as `LLM-ready`.
-- Exclude folders, tags, and frontmatter-based note groups from traversal.
+- Exclude folders, tags, and notes based on frontmatter properties (property rules) from traversal.
 - Copy exports to the clipboard or create a new note directly in your vault.
 - Rewrite links between exported notes so navigation still works inside the generated Markdown note.
 
@@ -44,9 +44,8 @@ Use [BRAT (Beta Reviewers Auto-update Tool)](https://github.com/TfTHacker/obsidi
 ## Export Formats
 
 - **XML** for structured machine-readable exports.
-- **LLM-ready Markdown** for prompt and context workflows.
+- **Markdown templates** for prompt and context workflows, including the built-in `LLM-ready` template and custom templates loaded from your vault.
 - **Print-friendly Markdown** for readable note bundles, PDF export, and linked tables of contents.
-- **Custom Markdown templates** loaded from your vault.
 
 ## Core Features
 

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -71,7 +71,7 @@ When upgrading between two known versions, the modal may include both the previo
 release and the new release in the same view instead of showing only strictly unseen
 entries. This matches the intended "what's new" recap behavior.
 
-## Prerelease flow (for BRAT testing)
+## Prerelease flow (optional BRAT beta testing)
 
 Use this flow when a feature is still in a PR branch and should be tested without a final release:
 
@@ -95,7 +95,7 @@ git tag -a 1.3.0-beta.1 -m "1.3.0 beta 1"
 git push origin 1.3.0-beta.1
 ```
 
-5. Share release for BRAT testing.
+5. Share the prerelease for BRAT beta testing or other manual prerelease install flows.
 
 ## Final release flow
 

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -1,6 +1,6 @@
 # Versioning and Releases
 
-Updated: March 4, 2026
+Updated: April 22, 2026
 
 ## Overview
 

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -71,9 +71,9 @@ When upgrading between two known versions, the modal may include both the previo
 release and the new release in the same view instead of showing only strictly unseen
 entries. This matches the intended "what's new" recap behavior.
 
-## Prerelease flow (optional BRAT beta testing)
+## Prerelease flow
 
-Use this flow when a feature is still in a PR branch and should be tested without a final release:
+Use this flow when a feature should be tested before a final release. If the work is still in a PR branch, BRAT can be used as an optional beta-testing path:
 
 1. On your branch, bump version to a prerelease:
 


### PR DESCRIPTION
## Description

Refresh the public-facing docs now that Smart Export is available in Obsidian Community Plugins.

This PR also reshapes the README so it reads more like a landing page: clearer positioning, a trimmed badge row, Community Plugins as the recommended install path, and BRAT framed only as optional beta testing.

**Related Issue(s):** Fixes #74

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Code style/formatting
- [ ] Refactoring
- [ ] Performance improvements
- [ ] Tests
- [ ] Maintenance

## Testing

- [x] Manual testing performed
- [ ] Tests added/updated
- [x] All existing tests pass

## Checklist

- [x] Code follows existing style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings/errors
- [x] Linting passes
- [x] Backwards compatibility maintained

## Additional Notes

- README badge row now keeps version, Obsidian downloads, and Buy Me a Coffee only.
- docs/versioning-and-releases.md now describes BRAT as an optional prerelease flow instead of the main install path.