### PR TITLE
chore: establish release QA validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,23 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  test-status:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: test
+
+    steps:
+      - name: Require all test matrix jobs
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            exit 1
+          fi
+
   build:
     name: Build Plugin (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: test
+    needs: test-status
     strategy:
       fail-fast: false
       matrix:
@@ -92,3 +105,16 @@ jobs:
             manifest.json
             styles.css
           retention-days: 7
+
+  build-status:
+    name: Build Plugin
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: build
+
+    steps:
+      - name: Require all build matrix jobs
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,12 @@ on:
 
 jobs:
   test:
-    name: Test & Lint
-    runs-on: ubuntu-latest
+    name: Test & Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -40,6 +44,7 @@ jobs:
         run: pnpm test
 
       - name: Upload coverage reports
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage/lcov.info
@@ -50,9 +55,13 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
-    name: Build Plugin
-    runs-on: ubuntu-latest
+    name: Build Plugin (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -74,6 +83,7 @@ jobs:
         run: pnpm build
 
       - name: Upload build artifacts
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: plugin-build

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Placeholder reference: [`templates/README.md`](templates/README.md)
 - [Content redaction](docs/content-redaction.md)
 - [Export architecture](docs/export-architecture.md)
 - [Startup process](docs/startup-process.md)
+- [Release QA checklist](docs/qa-release-checklist.md)
 - [Codex Cloud and coding agent setup](docs/codex-cloud.md)
 - [Versioning and releases](docs/versioning-and-releases.md)
 - [Template placeholders](templates/README.md)
@@ -248,7 +249,7 @@ Optional WSL/Linux workflow:
 Benchmark:
 
 ```bash
-pnpm benchmark
+pnpm benchmark:check
 ```
 
 See [recorded benchmark results](benchmarks/README.md) for the current synthetic baseline

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,14 +1,21 @@
 # Performance benchmarks
 
-Run the synthetic performance suite from the repository root:
+Run the synthetic performance suite and enforce the accepted regression tolerances from the
+repository root:
 
 ```bash
-pnpm benchmark
+pnpm benchmark:check
 ```
 
-The command measures traversal/export throughput and tag discovery on a synthetic large vault.
-It writes the most recent machine-readable result to the ignored
-`benchmarks/latest-report.json` file so local runs do not create working-tree changes.
+`pnpm benchmark` remains available when a report is needed without enforcing the gate. Both
+commands measure traversal/export throughput and tag discovery on synthetic large-vault fixtures:
+
+- a deterministic 1,365-note, five-level graph with 85 simulated content reads;
+- 10,000 tagged notes distributed across 100 nested tag groups plus a shared tag.
+
+No private vault data is read or stored. The suite writes the latest machine-readable result to
+the ignored `benchmarks/latest-report.json` file. `benchmark:check` compares it with the committed
+`benchmarks/baseline.json` file.
 
 ## Recorded baseline
 
@@ -28,3 +35,18 @@ an indicative baseline rather than a universal threshold.
 The traversal fixture estimates 425 ms of serial read cost, corresponding to a 7.29x
 speedup in this run. The tag benchmark invalidates the cache before every cold run and
 reuses the same result for every warm run.
+
+## Regression tolerances
+
+The release gate allows traversal/export/tag-discovery duration medians to increase by at most
+25%. Estimated traversal speedup may drop by at most 20%. The warm-cache tag timing is reported but
+is not gated because sub-microsecond timer noise makes ratios misleading.
+
+Run the check on the same machine with background workloads minimized. When it fails, rerun once to
+exclude transient contention. A repeatable failure blocks release unless the completed
+[release QA evidence](../docs/qa-release-checklist.md) documents the environment difference, user
+impact, owner, and follow-up issue.
+
+Promote a new baseline only for an intentional, reviewed fixture or environment change. Record the
+capture date, commit, operating system, architecture, Node.js, and pnpm versions in
+`benchmarks/baseline.json`; never replace the baseline merely to make a regression pass.

--- a/benchmarks/baseline.json
+++ b/benchmarks/baseline.json
@@ -1,0 +1,22 @@
+{
+  "capturedAt": "2026-07-31",
+  "commit": "0389579",
+  "environment": {
+    "operatingSystem": "Windows build 26200",
+    "architecture": "AMD64",
+    "node": "24.14.1",
+    "pnpm": "11.18.0"
+  },
+  "tolerances": {
+    "maximumMedianRegressionPercent": 25,
+    "maximumTraversalSpeedupDropPercent": 20
+  },
+  "metrics": {
+    "traversalMedianMs": 58.34,
+    "estimatedTraversalSpeedup": 7.29,
+    "xmlMedianMs": 0.86,
+    "llmMedianMs": 1.87,
+    "printMedianMs": 3.06,
+    "tagColdMedianMs": 11.81
+  }
+}

--- a/benchmarks/export-performance.bench.ts
+++ b/benchmarks/export-performance.bench.ts
@@ -17,6 +17,19 @@ interface GraphFixture {
 	rootPath: string;
 }
 
+const GRAPH_FIXTURE = {
+	branchingFactor: 4,
+	maxDepth: 5,
+	contentDepth: 3,
+	contentSize: 400,
+	readDelayMs: 5,
+} as const;
+
+const TAG_FIXTURE = {
+	noteCount: 10_000,
+	groupCount: 100,
+} as const;
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -124,8 +137,10 @@ function createSyntheticTagFixture(noteCount: number): App {
 			getCache: (path: string) => {
 				const noteIndex = Number.parseInt(path.slice("tags/note-".length, -".md".length), 10);
 				return {
-					tags: [{ tag: `#group/${noteIndex % 100}` }],
-					frontmatter: { tags: [`group/${noteIndex % 100}`, "shared"] },
+					tags: [{ tag: `#group/${noteIndex % TAG_FIXTURE.groupCount}` }],
+					frontmatter: {
+						tags: [`group/${noteIndex % TAG_FIXTURE.groupCount}`, "shared"],
+					},
 				};
 			},
 		},
@@ -180,22 +195,23 @@ function measureSyncRuns(runs: number, task: () => void): number[] {
 
 describe("Performance benchmarks", () => {
 	it("benchmarks traversal and exporter throughput on a 1k+ note synthetic graph", async () => {
-		const branchingFactor = 4;
-		const traversalDepth = 5;
-		const contentDepth = 3;
-		const perReadDelayMs = 5;
 		const traversalRuns = 5;
 		const exporterRuns = 30;
 		const fixture = createSyntheticGraphFixture(
-			branchingFactor,
-			traversalDepth,
-			400,
-			perReadDelayMs
+			GRAPH_FIXTURE.branchingFactor,
+			GRAPH_FIXTURE.maxDepth,
+			GRAPH_FIXTURE.contentSize,
+			GRAPH_FIXTURE.readDelayMs
 		);
 		const obsidianAPI = new ObsidianAPI(fixture.app);
 		let lastTree: ExportNode | null = null;
 		const traversalDurations = await measureAsyncRuns(traversalRuns, async () => {
-			const traversal = new BFSTraversal(obsidianAPI, contentDepth, traversalDepth, "outgoing");
+			const traversal = new BFSTraversal(
+				obsidianAPI,
+				GRAPH_FIXTURE.contentDepth,
+				GRAPH_FIXTURE.maxDepth,
+				"outgoing"
+			);
 			lastTree = await traversal.traverse(fixture.rootPath);
 		});
 
@@ -203,7 +219,7 @@ describe("Performance benchmarks", () => {
 		const rootTree = lastTree as ExportNode;
 		const nodeCounts = countNodes(rootTree);
 		const traversalMedian = median(traversalDurations);
-		const expectedSerialReadCostMs = nodeCounts.withContent * perReadDelayMs;
+		const expectedSerialReadCostMs = nodeCounts.withContent * GRAPH_FIXTURE.readDelayMs;
 		const estimatedSpeedup = expectedSerialReadCostMs / traversalMedian;
 
 		const xmlExporter = new XMLExporter();
@@ -223,7 +239,7 @@ describe("Performance benchmarks", () => {
 			printLength = printExporter.export(rootTree).length;
 		});
 
-		const tagFileCount = 10_000;
+		const tagFileCount = TAG_FIXTURE.noteCount;
 		const tagColdRuns = 5;
 		const tagCachedRuns = 1_000;
 		const tagDiscovery = new TagDiscoveryService(
@@ -256,6 +272,10 @@ describe("Performance benchmarks", () => {
 			"benchmarks/latest-report.json",
 			`${JSON.stringify(
 				{
+					fixture: {
+						graph: GRAPH_FIXTURE,
+						tags: TAG_FIXTURE,
+					},
 					nodesTraversed: nodeCounts.total,
 					nodesWithContentReads: nodeCounts.withContent,
 					traversalRuns,

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory contains public, plugin-specific documentation for Smart Export.
 - [API reference](api-reference.md)
 - [Export architecture](export-architecture.md)
 - [Startup process](startup-process.md)
+- [Release QA checklist](qa-release-checklist.md)
 - [Exclusion rules](exclude-folders.md)
 - [Content redaction](content-redaction.md)
 - [Codex Cloud and coding agent setup](codex-cloud.md)

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -130,12 +130,17 @@ Completion criteria:
 
 Before publishing any version:
 
-1. Run `pnpm format`.
-2. Run `pnpm format:check`.
-3. Run `pnpm lint`.
-4. Run `pnpm typecheck`.
-5. Run `pnpm test`.
-6. Run `pnpm build`.
-7. Test the production bundle in Obsidian desktop and at least one mobile runtime.
-8. Confirm `package.json`, `manifest.json`, `versions.json`, `CHANGELOG.md`, and bundled release notes use the same version.
-9. Create the stable tag from `main` without a `v` prefix; [#104](https://github.com/LittleHaku/obsidian-smart-export/issues/104) tracks automated enforcement.
+1. Complete the versioned [release QA checklist](qa-release-checklist.md) and commit or link its
+   release-candidate evidence.
+2. Run `pnpm format`.
+3. Run `pnpm format:check`.
+4. Run `pnpm lint`.
+5. Run `pnpm typecheck`.
+6. Run `pnpm test`.
+7. Run `pnpm build`.
+8. Run `pnpm benchmark:check` and record startup profiling on Windows and Linux.
+9. Test the production bundle on Windows, Linux, one real Android device, and one real iPhone or
+   iPad, including supported desktop pop-out windows.
+10. Confirm `package.json`, `manifest.json`, `versions.json`, `CHANGELOG.md`, and bundled release
+    notes use the same version.
+11. Create the stable tag from `main` without a `v` prefix; [#104](https://github.com/LittleHaku/obsidian-smart-export/issues/104) tracks automated enforcement.

--- a/docs/qa-release-checklist.md
+++ b/docs/qa-release-checklist.md
@@ -1,0 +1,134 @@
+# Release QA checklist
+
+Updated: August 1, 2026
+
+Use this checklist for every release candidate. Store the completed evidence as
+`docs/qa-results/<version>-rc.<number>.md`, starting from the
+[release evidence template](qa-results/template.md). Evidence is committed with the release
+candidate or linked from its pull request before a stable tag is created.
+
+## Release gate
+
+A release candidate is ready only when:
+
+- all automated checks pass on Windows and Linux;
+- every applicable manual scenario below passes on Windows, Linux, one real Android device, and
+  one real iPhone or iPad;
+- desktop pop-out-window scenarios pass on Windows and Linux;
+- startup measurements and `pnpm benchmark:check` are recorded;
+- no unexplained material regression remains.
+
+Use `PASS`, `FAIL`, `BLOCKED`, or `NOT RUN` in evidence. `FAIL`, `BLOCKED`, and required `NOT RUN`
+results block a stable release. Do not substitute desktop mobile emulation for the required real
+Android and iOS/iPadOS runs.
+
+## Candidate and environment
+
+Record the following before testing:
+
+- release candidate version and exact commit;
+- production build (`pnpm build`), not a development bundle;
+- Obsidian version and installer channel;
+- operating-system version, device model, and architecture;
+- vault fixture name and approximate note count;
+- enabled community plugins other than Smart Export;
+- tester and date.
+
+Use a disposable vault containing linked notes, backlinks, inline and frontmatter tags, excluded
+folders, excluded properties, custom templates, missing links, and enough notes to exercise both
+content and title depth. Never commit private vault content.
+
+## Automated validation
+
+Run from a fresh dependency install on both Windows PowerShell and a native Linux filesystem:
+
+```bash
+corepack enable pnpm
+pnpm install --frozen-lockfile
+pnpm format:check
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+GitHub Actions executes the same formatting, linting, type checking, and test commands on
+`windows-latest` and `ubuntu-latest`. Record the workflow URL and the local command results. Keep
+separate `node_modules` installations when using Windows and WSL/Linux.
+
+The lifecycle test in `tests/main.test.ts` must continue to prove that `onload()` performs no
+vault-wide file enumeration, metadata scan, cached note read, or export traversal. The vault
+`create` listener must remain inside `workspace.onLayoutReady(...)`.
+
+## Manual smoke-test matrix
+
+Run each applicable scenario on Windows, Linux, Android, and iOS/iPadOS. Run `POP-01` and `POP-02`
+only on desktop platforms that support pop-out windows.
+
+| ID       | Scenario                                           | Expected result                                                                  |
+| -------- | -------------------------------------------------- | -------------------------------------------------------------------------------- |
+| LOAD-01  | Enable/reload plugin                               | Plugin loads without console errors, startup scan, or unsolicited notice.        |
+| SET-01   | Open and search settings                           | All controls render, search, persist, and restore after reload.                  |
+| SET-02   | Load settings saved by the previous stable version | Values migrate without reset, corruption, or layout overflow.                    |
+| SRC-01   | Select a root note                                 | Tree preview reflects content/title depth and linked notes.                      |
+| SRC-02   | Select a tag source                                | Matching inline/frontmatter-tag notes appear in stable path order.               |
+| SRC-03   | Add a single note, new root, and extra tag         | Additions are composed once and duplicate notes are deduplicated.                |
+| LINK-01  | Export outgoing links                              | Only configured outgoing traversal is included.                                  |
+| LINK-02  | Export backlinks                                   | Incoming traversal is included without missing or duplicate nodes.               |
+| LINK-03  | Export both directions                             | Incoming and outgoing traversal are combined correctly.                          |
+| EXCL-01  | Apply folder, tag, and property exclusions         | Matching notes are absent and are not traversed further.                         |
+| PICK-01  | Use note, tag, folder, and template selectors      | Suggestions open, filter, select, and close without stale state.                 |
+| OUT-01   | XML to clipboard                                   | Valid XML is copied and the success notice is shown.                             |
+| OUT-02   | LLM-ready Markdown to clipboard                    | Templated Markdown is copied with expected metadata and rewritten links.         |
+| OUT-03   | Print-friendly Markdown to clipboard               | TOC, numbering, headings, dividers, and page-break options behave as configured. |
+| OUT-04   | Custom Markdown template                           | Selected placeholders resolve; missing template falls back safely.               |
+| NOTE-01  | Export each format to a new note                   | Unique note is created in the selected folder and opens only when configured.    |
+| REDACT-1 | Export marked-section and regex redaction          | Export is redacted without modifying source notes.                               |
+| CANCEL-1 | Cancel destination picker and close during preview | No note/output is created and no stale async result updates the closed modal.    |
+| NOTICE-1 | Trigger missing link, unavailable clipboard, error | Notices are readable, actionable, and do not repeat unexpectedly.                |
+| REL-01   | Upgrade from previous version                      | Release notes appear once and the seen state persists after closing.             |
+| POP-01   | Run selectors and clipboard export in pop-out      | Controls use the owning window/document and export succeeds.                     |
+| POP-02   | Close release notes in pop-out                     | Focus and close behavior stay in the owning window without errors.               |
+
+Also repeat `SET-01`, `SRC-02`, `PICK-01`, and `NOTE-01` in phone and tablet layouts when both are
+available. Record screenshots only when they help explain a failure; redact vault names and note
+content before attaching them.
+
+## Startup/load-time measurement
+
+Follow Obsidian's startup profiler procedure documented in
+[Startup process](startup-process.md#startup-validation). Use the production bundle and the same
+vault/profile as the previous accepted baseline.
+
+Record five cold launches per desktop platform and report the median Smart Export load time. A
+candidate is a material startup regression when its median is both more than 25% and more than
+5 ms slower than the previous accepted median. Confirm that no vault-wide work appears during
+startup. A material regression blocks release unless the evidence identifies the cause, user
+impact, owner, and follow-up issue.
+
+## Large-vault benchmark
+
+Run:
+
+```bash
+pnpm benchmark:check
+```
+
+The suite creates synthetic 1,365-note traversal and 10,000-note tag fixtures; it never reads a
+private vault. It compares the new medians with `benchmarks/baseline.json`. Duration medians may
+increase by at most 25%, and estimated traversal speedup may drop by at most 20%. A failed check
+blocks release unless the completed evidence documents the environment-sensitive exception and a
+follow-up issue.
+
+## Release decision
+
+The completed evidence must link the candidate PR/workflow, list every exception, and end with one
+decision: `GO` or `NO-GO`. The release checklist in [Maintenance plan](maintenance.md#release-readiness)
+links here so a stable tag cannot be prepared without reviewing the evidence.
+
+## References
+
+- [Obsidian load-time guide](https://docs.obsidian.md/plugins/guides/load-time)
+- [Performance benchmark methodology](../benchmarks/README.md)
+- [Startup process](startup-process.md)
+- [Testing and coverage](testing.md)

--- a/docs/qa-results/template.md
+++ b/docs/qa-results/template.md
@@ -1,0 +1,62 @@
+# QA evidence VERSION-rc.N
+
+- Candidate version:
+- Commit:
+- Pull request/workflow:
+- Tester and date:
+- Final decision: `GO` / `NO-GO`
+
+## Environments
+
+| Platform   | OS/device | Architecture | Obsidian | Smart Export | Vault fixture | Other plugins |
+| ---------- | --------- | ------------ | -------- | ------------ | ------------- | ------------- |
+| Windows    |           |              |          |              |               |               |
+| Linux      |           |              |          |              |               |               |
+| Android    |           |              |          |              |               |               |
+| iOS/iPadOS |           |              |          |              |               |               |
+
+## Automated checks
+
+| Platform | Install | Format | Lint | Types | Tests | Build | Evidence link |
+| -------- | ------- | ------ | ---- | ----- | ----- | ----- | ------------- |
+| Windows  |         |        |      |       |       |       |               |
+| Linux    |         |        |      |       |       |       |               |
+
+## Manual smoke tests
+
+Copy the IDs from the [release QA checklist](../qa-release-checklist.md#manual-smoke-test-matrix).
+
+| ID  | Windows | Linux | Android | iOS/iPadOS | Notes/evidence |
+| --- | ------- | ----- | ------- | ---------- | -------------- |
+|     |         |       |         |            |                |
+
+## Startup measurements
+
+Record milliseconds from five cold launches and calculate the median.
+
+| Platform | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 | Median | Previous median | Change |
+| -------- | ----: | ----: | ----: | ----: | ----: | -----: | --------------: | -----: |
+| Windows  |       |       |       |       |       |        |                 |        |
+| Linux    |       |       |       |       |       |        |                 |        |
+
+- Production bundle confirmed:
+- No vault-wide startup work observed:
+- Profiler screenshot/log link:
+
+## Large-vault benchmark
+
+- Command: `pnpm benchmark:check`
+- Environment:
+- Result: `PASS` / `FAIL`
+- `benchmarks/latest-report.json` summary or artifact link:
+- Difference from `benchmarks/baseline.json`:
+
+## Regressions and exceptions
+
+List each failure, blocker, accepted exception, owner, and follow-up issue. Write `None` when all
+required checks pass.
+
+## Decision
+
+State why the candidate is `GO` or `NO-GO`, including confirmation that real Android and
+iOS/iPadOS runs were completed.

--- a/docs/startup-process.md
+++ b/docs/startup-process.md
@@ -15,6 +15,7 @@ Updated: August 1, 2026
   - [Ignored note filtering](#ignored-note-filtering)
   - [Debounced settings writes](#debounced-settings-writes)
 - [Shutdown Process](#shutdown-process)
+- [Startup Validation](#startup-validation)
 
 ## Overview
 
@@ -113,3 +114,21 @@ Trigger: `Plugin.onunload()` in `src/main.ts`.
 
 No long-lived background workers are started by Smart Export. Obsidian disposes the registered
 tag-cache event references through the plugin lifecycle, so unload remains lightweight.
+
+## Startup Validation
+
+Use a production bundle and follow Obsidian's official load-time workflow:
+
+1. Run `pnpm build` and install the generated bundle in a disposable test vault.
+2. Open **Settings → General → Advanced** and select the stopwatch icon for startup profiling.
+3. Keep the vault, enabled-plugin set, Obsidian version, and device unchanged between candidates.
+4. Fully close Obsidian, perform five cold launches, and record Smart Export's load time for each.
+5. Record the median and compare it with the previous accepted release candidate.
+
+The lifecycle test also asserts that plugin load does not enumerate vault files, scan Markdown
+metadata, read note contents, or start export traversal. The `create` listener remains deferred
+until `workspace.onLayoutReady(...)`, matching Obsidian's load-time guidance.
+
+Record measurements in a copy of the
+[release evidence template](qa-results/template.md). The complete platform matrix, tolerances, and
+release-blocking rules live in the [release QA checklist](qa-release-checklist.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,8 @@ Use focused Vitest commands while developing, but always finish with `pnpm test`
 
 ## Cross-platform determinism
 
-Coverage uses Vitest's V8 provider, repository-relative source globs, and LCOV/JSON/HTML/text reporters. The same `pnpm test` command is used on Windows development machines and Linux CI; generated `coverage/` output is ignored and must not be committed.
+Coverage uses Vitest's V8 provider, repository-relative source globs, and LCOV/JSON/HTML/text
+reporters. GitHub Actions runs the same formatting, linting, type checking, and test commands on
+Windows and Linux; generated `coverage/` output is ignored and must not be committed.
 
 Tests must not depend on platform-specific path separators, locale-formatted coverage paths, network access, wall-clock timing, or test execution order.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"typecheck": "tsc --noEmit --skipLibCheck",
 		"test": "vitest run --coverage",
 		"check": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test",
-		"benchmark": "vitest run --config vitest.benchmark.config.ts"
+		"benchmark": "vitest run --config vitest.benchmark.config.ts",
+		"benchmark:check": "pnpm run benchmark && node scripts/check-benchmark-regression.mjs"
 	},
 	"keywords": [
 		"obsidian",

--- a/scripts/check-benchmark-regression.mjs
+++ b/scripts/check-benchmark-regression.mjs
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const baseline = JSON.parse(await readFile("benchmarks/baseline.json", "utf8"));
+const current = JSON.parse(await readFile("benchmarks/latest-report.json", "utf8"));
+const maximumDurationMultiplier =
+	1 + baseline.tolerances.maximumMedianRegressionPercent / 100;
+const minimumSpeedupMultiplier =
+	1 - baseline.tolerances.maximumTraversalSpeedupDropPercent / 100;
+
+const durationMetrics = [
+	"traversalMedianMs",
+	"xmlMedianMs",
+	"llmMedianMs",
+	"printMedianMs",
+	"tagColdMedianMs",
+];
+const failures = [];
+
+for (const metric of durationMetrics) {
+	const allowedMaximum = baseline.metrics[metric] * maximumDurationMultiplier;
+	if (current[metric] > allowedMaximum) {
+		failures.push(
+			`${metric}: ${current[metric]} ms exceeds the ${allowedMaximum.toFixed(2)} ms limit`
+		);
+	}
+}
+
+const minimumTraversalSpeedup =
+	baseline.metrics.estimatedTraversalSpeedup * minimumSpeedupMultiplier;
+if (current.estimatedTraversalSpeedup < minimumTraversalSpeedup) {
+	failures.push(
+		`estimatedTraversalSpeedup: ${current.estimatedTraversalSpeedup}x is below the ${minimumTraversalSpeedup.toFixed(2)}x limit`
+	);
+}
+
+if (failures.length > 0) {
+	process.stderr.write(`Benchmark regression detected:\n- ${failures.join("\n- ")}\n`);
+	process.exitCode = 1;
+} else {
+	process.stdout.write(
+		`Benchmark check passed against ${baseline.commit} (${baseline.capturedAt}).\n`
+	);
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -140,9 +140,19 @@ function createApp(activeFile: TFile | null = null): {
 	app: App;
 	layoutCallbacks: Array<() => void>;
 	eventCallbacks: Array<() => void>;
+	startupReads: {
+		cachedRead: ReturnType<typeof vi.fn>;
+		getCache: ReturnType<typeof vi.fn>;
+		getFiles: ReturnType<typeof vi.fn>;
+		getMarkdownFiles: ReturnType<typeof vi.fn>;
+	};
 } {
 	const layoutCallbacks: Array<() => void> = [];
 	const eventCallbacks: Array<() => void> = [];
+	const cachedRead = vi.fn(async () => "");
+	const getCache = vi.fn(() => null);
+	const getFiles = vi.fn(() => []);
+	const getMarkdownFiles = vi.fn(() => []);
 	const app = new App();
 	Object.assign(app, {
 		metadataCache: {
@@ -150,16 +160,18 @@ function createApp(activeFile: TFile | null = null): {
 				eventCallbacks.push(callback);
 				return { name };
 			}),
-			getCache: vi.fn(() => null),
+			getCache,
 		},
 		vault: {
 			on: vi.fn((name: string, callback: () => void) => {
 				eventCallbacks.push(callback);
 				return { name };
 			}),
+			cachedRead,
+			getFiles,
 			getName: vi.fn(() => "Test vault"),
 			getFileByPath: vi.fn(() => null),
-			getMarkdownFiles: vi.fn(() => []),
+			getMarkdownFiles,
 		},
 		workspace: {
 			getActiveFile: vi.fn(() => activeFile),
@@ -168,7 +180,12 @@ function createApp(activeFile: TFile | null = null): {
 			}),
 		},
 	});
-	return { app, layoutCallbacks, eventCallbacks };
+	return {
+		app,
+		layoutCallbacks,
+		eventCallbacks,
+		startupReads: { cachedRead, getCache, getFiles, getMarkdownFiles },
+	};
 }
 
 function createPlugin(app = createApp().app): SmartExportPlugin {
@@ -228,7 +245,7 @@ describe("SmartExportPlugin lifecycle", () => {
 
 	it("registers lifecycle-safe events, entry points, settings, and deferred work", async () => {
 		const activeFile = createFile("Root.md");
-		const { app, layoutCallbacks, eventCallbacks } = createApp(activeFile);
+		const { app, layoutCallbacks, eventCallbacks, startupReads } = createApp(activeFile);
 		const plugin = createPlugin(app);
 		const loadSettings = vi.spyOn(plugin, "loadSettings").mockResolvedValue();
 		const ribbonCallbacks: Array<(event: MouseEvent) => void> = [];
@@ -251,6 +268,10 @@ describe("SmartExportPlugin lifecycle", () => {
 
 		await plugin.onload();
 		expect(loadSettings).toHaveBeenCalledOnce();
+		expect(startupReads.getFiles).not.toHaveBeenCalled();
+		expect(startupReads.getMarkdownFiles).not.toHaveBeenCalled();
+		expect(startupReads.cachedRead).not.toHaveBeenCalled();
+		expect(startupReads.getCache).not.toHaveBeenCalled();
 		expect(registerEvent).toHaveBeenCalledTimes(4);
 		expect(addSettingTab).toHaveBeenCalledOnce();
 		expect(layoutCallbacks).toHaveLength(1);
@@ -269,6 +290,10 @@ describe("SmartExportPlugin lifecycle", () => {
 		expect(quickExport).toHaveBeenCalledWith(activeFile);
 
 		layoutCallbacks[0]?.();
+		expect(startupReads.getFiles).not.toHaveBeenCalled();
+		expect(startupReads.getMarkdownFiles).not.toHaveBeenCalled();
+		expect(startupReads.cachedRead).not.toHaveBeenCalled();
+		expect(startupReads.getCache).not.toHaveBeenCalled();
 		expect(registerEvent).toHaveBeenCalledTimes(5);
 		expect(maybeShowReleaseNotes).toHaveBeenCalledOnce();
 		plugin.onunload();


### PR DESCRIPTION
## Description

Establishes the repeatable release QA and performance-validation workflow requested in #102.

- Adds a versioned Windows, Linux, Android, and iOS/iPadOS smoke-test matrix covering core export paths, selectors, exclusions, backlinks, cancellation, notices, and supported pop-out windows.
- Adds a release evidence template with explicit startup measurements, real-device results, regression exceptions, and GO/NO-GO decisions.
- Runs test and production-build jobs on both Windows and Linux in CI.
- Adds deterministic 1,365-note traversal and 10,000-note tag benchmark fixture metadata, a committed baseline, and an executable regression gate.
- Strengthens lifecycle coverage so `onload()` is proven not to enumerate, scan, or read the vault.

**Related Issue(s):** Refs #102. Keep the issue open until the first release-candidate evidence records real Android and iOS/iPadOS runs.

**Release:** `none` — documentation, tests, benchmarks, and CI only; shipped plugin behavior is unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code style/formatting
- [ ] Refactoring
- [x] Performance improvements
- [x] Tests
- [x] Maintenance

## Testing

- [x] Manual testing performed (`pnpm benchmark:check` and production build on Windows)
- [x] Tests added/updated
- [x] All existing tests pass

Validation completed:

- `pnpm format`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 381 tests, 100% statements/branches/functions/lines
- `pnpm build`
- `pnpm benchmark:check` — passed against baseline `0389579`

Latest local benchmark: 57.62 ms traversal median, 7.38x estimated traversal speedup, and all exporter/tag-discovery medians within tolerance.

## Checklist

- [x] Code follows existing style
- [x] Self-review completed
- [x] Documentation updated
- [x] `Release: none` is justified
- [x] No new warnings/errors
- [x] Linting passes
- [x] Backwards compatibility maintained

## Additional Notes

Real Android and iOS/iPadOS results are intentionally not fabricated. The new checklist makes both physical-device runs mandatory before a stable release and provides the versioned evidence format needed to record them.
